### PR TITLE
Spelling correction in 05-terraform.md

### DIFF
--- a/docs/05-terraform.md
+++ b/docs/05-terraform.md
@@ -76,7 +76,7 @@ resource "google_compute_instance" "raddit" {
   # networks to attach to the VM
   network_interface {
     network = "default"
-    access_config {} // use ephemaral public IP
+    access_config {} // use ephemeral public IP
   }
 }
 ```


### PR DESCRIPTION
Replacing "ephemaral" with "ephemeral"